### PR TITLE
Add dedicated storage class option for Nextcloud data PVC

### DIFF
--- a/nextcloud-aio-helm-chart/templates/nextcloud-aio-nextcloud-data-persistentvolumeclaim.yaml
+++ b/nextcloud-aio-helm-chart/templates/nextcloud-aio-nextcloud-data-persistentvolumeclaim.yaml
@@ -6,7 +6,9 @@ metadata:
   name: nextcloud-aio-nextcloud-data
   namespace: "{{ .Values.NAMESPACE }}"
 spec:
-  {{- if .Values.STORAGE_CLASS }}
+  {{- if .Values.STORAGE_CLASS_DATA }}
+  storageClassName: {{ .Values.STORAGE_CLASS_DATA }}
+  {{- else if .Values.STORAGE_CLASS }}
   storageClassName: {{ .Values.STORAGE_CLASS }}
   {{- end }}
   accessModes:

--- a/nextcloud-aio-helm-chart/update-helm.sh
+++ b/nextcloud-aio-helm-chart/update-helm.sh
@@ -216,11 +216,18 @@ find ./ -name '*persistentvolumeclaim.yaml' -exec sed -i "s|ReadOnlyMany|ReadWri
 # shellcheck disable=SC1083
 find ./ -name 'nextcloud-aio-nextcloud-persistentvolumeclaim.yaml' -exec sed -i "s|ReadWriteOnce|ReadWriteMany|"  \{} \;
 # shellcheck disable=SC1083
-find ./ -name '*persistentvolumeclaim.yaml' -exec sed -i "/accessModes:/i\ \ {{- if .Values.STORAGE_CLASS }}" \{} \;  
+find ./ -name '*persistentvolumeclaim.yaml' -exec sed -i "/accessModes:/i\ \ {{- if .Values.STORAGE_CLASS }}" \{} \;
 # shellcheck disable=SC1083
-find ./ -name '*persistentvolumeclaim.yaml' -exec sed -i "/accessModes:/i\ \ storageClassName: {{ .Values.STORAGE_CLASS }}" \{} \; 
+find ./ -name '*persistentvolumeclaim.yaml' -exec sed -i "/accessModes:/i\ \ storageClassName: {{ .Values.STORAGE_CLASS }}" \{} \;
 # shellcheck disable=SC1083
-find ./ -name '*persistentvolumeclaim.yaml' -exec sed -i "/accessModes:/i\ \ {{- end }}" \{} \; 
+find ./ -name '*persistentvolumeclaim.yaml' -exec sed -i "/accessModes:/i\ \ {{- end }}" \{} \;
+# Adjust nextcloud data pvc to optionally use STORAGE_CLASS_DATA
+# shellcheck disable=SC1083
+find ./ -name 'nextcloud-aio-nextcloud-data-persistentvolumeclaim.yaml' -exec sed -i "/{{- if .Values.STORAGE_CLASS }}/i\  {{- if .Values.STORAGE_CLASS_DATA }}\n  storageClassName: {{ .Values.STORAGE_CLASS_DATA }}" \{} \;
+# shellcheck disable=SC1083
+find ./ -name 'nextcloud-aio-nextcloud-data-persistentvolumeclaim.yaml' -exec sed -i "s/{{- if .Values.STORAGE_CLASS }}/{{- else if .Values.STORAGE_CLASS }}/" \{} \;
+# shellcheck disable=SC1083
+find ./ -name 'nextcloud-aio-nextcloud-data-persistentvolumeclaim.yaml' -exec sed -i "/storageClassName: {{ .Values.STORAGE_CLASS }}/a\  {{- end }}" \{} \;
 # shellcheck disable=SC1083
 find ./ -name '*deployment.yaml' -exec sed -i "/restartPolicy:/d" \{} \;  
 # shellcheck disable=SC1083
@@ -407,6 +414,7 @@ sed -i 's|17179869184|"17179869184"|' /tmp/sample.conf
 echo "" >> /tmp/sample.conf
 # shellcheck disable=SC2129
 echo 'STORAGE_CLASS:        # By setting this, you can adjust the storage class for your volumes' >> /tmp/sample.conf
+echo 'STORAGE_CLASS_DATA:        # Allows to set a dedicated storage class for the Nextcloud data volume' >> /tmp/sample.conf
 for variable in "${VOLUME_VARIABLE[@]}"; do
     echo "$variable: 1Gi       # You can change the size of the $(echo "$variable" | sed 's|_STORAGE_SIZE||;s|_|-|g' | tr '[:upper:]' '[:lower:]') volume that default to 1Gi with this value" >> /tmp/sample.conf
 done

--- a/nextcloud-aio-helm-chart/values.yaml
+++ b/nextcloud-aio-helm-chart/values.yaml
@@ -39,6 +39,7 @@ TALK_PORT: 3478          # This allows to adjust the port that the talk containe
 UPDATE_NEXTCLOUD_APPS: no          # When setting to yes (with quotes), it will automatically update all installed Nextcloud apps upon container startup on saturdays.
 
 STORAGE_CLASS:        # By setting this, you can adjust the storage class for your volumes
+STORAGE_CLASS_DATA:        # Allows to set a dedicated storage class for the Nextcloud data volume
 APACHE_STORAGE_SIZE: 1Gi       # You can change the size of the apache volume that default to 1Gi with this value
 CLAMAV_STORAGE_SIZE: 1Gi       # You can change the size of the clamav volume that default to 1Gi with this value
 DATABASE_STORAGE_SIZE: 1Gi       # You can change the size of the database volume that default to 1Gi with this value


### PR DESCRIPTION
## Summary
- allow specifying `STORAGE_CLASS_DATA` for the `nextcloud-aio-nextcloud-data` PVC
- update templates and generation script to support the new value
- document the new value in `values.yaml`

## Testing
- `helm lint nextcloud-aio-helm-chart`

------
https://chatgpt.com/codex/tasks/task_e_684f3052c8dc83339540a2b3580f1a4d